### PR TITLE
Bigger picture for group president when only one groupe is displayed,…

### DIFF
--- a/src/components/deputies-list/DeputiesList.tsx
+++ b/src/components/deputies-list/DeputiesList.tsx
@@ -25,6 +25,13 @@ export default function DeputiesList() {
     }
   }).filter((groupe) => groupe.value !== 0)
 
+  const isPresidentGroupe = state.FilteredList.some(
+    (depute) => depute.ResponsabiliteGroupe.Fonction === "président" || depute.ResponsabiliteGroupe.Fonction === "présidente"
+  )
+  const presidentGroupe = state.FilteredList.find(
+    (depute) => depute.ResponsabiliteGroupe.Fonction === "président" || depute.ResponsabiliteGroupe.Fonction === "présidente"
+  )
+
   return (
     <>
       <section className="filters__section">
@@ -53,13 +60,37 @@ export default function DeputiesList() {
 
       <section className="deputies__list">
         {state.FilteredList.length > 0 ? (
-          state.FilteredList.map((depute) => {
-            return (
-              <LazyLoadComponent key={depute.Slug}>
-                <Deputy depute={depute} />
-              </LazyLoadComponent>
-            )
-          })
+          groupesData.length > 1 ? (
+            state.FilteredList.map((depute) => {
+              return (
+                <LazyLoadComponent key={depute.Slug}>
+                  <Deputy depute={depute} />
+                </LazyLoadComponent>
+              )
+            })
+          ) : isPresidentGroupe ? (
+            <>
+              <Deputy depute={presidentGroupe} groupNumber={groupesData.length} />
+              {state.FilteredList.filter(
+                (depute) =>
+                  depute.ResponsabiliteGroupe.Fonction !== "président" && depute.ResponsabiliteGroupe.Fonction !== "présidente"
+              ).map((depute) => {
+                return (
+                  <LazyLoadComponent key={depute.Slug}>
+                    <Deputy depute={depute} />
+                  </LazyLoadComponent>
+                )
+              })}
+            </>
+          ) : (
+            state.FilteredList.map((depute) => {
+              return (
+                <LazyLoadComponent key={depute.Slug}>
+                  <Deputy depute={depute} />
+                </LazyLoadComponent>
+              )
+            })
+          )
         ) : (
           <div className="deputies__no-result">Aucun résultat ne correspond à votre recherche</div>
         )}

--- a/src/components/deputies-list/deputy/Deputy.tsx
+++ b/src/components/deputies-list/deputy/Deputy.tsx
@@ -5,22 +5,25 @@ import DeputyImage from "components/deputy/general-information/deputy-image/Depu
 
 interface IOneDeputy {
   depute: Deputy.Deputy
+  groupNumber?: number
 }
 
-export default function OneDeputy({ depute }: IOneDeputy) {
+export default function OneDeputy({ depute, groupNumber }: IOneDeputy) {
   const GroupLogo = getGroupLogo(depute.GroupeParlementaire.Sigle)
-
+  const isPresidentGroupe =
+    depute.ResponsabiliteGroupe.Fonction === "président" || depute.ResponsabiliteGroupe.Fonction === "présidente"
   return (
     <>
       <Link href={`/depute/${depute.Slug}`}>
         <a
           id={"depute-" + depute.Slug}
-          className={"depute"}
+          className={`depute${isPresidentGroupe && groupNumber == 1 ? " depute__president" : ""}`}
           style={{
             backgroundColor: depute.GroupeParlementaire.Couleur,
           }}
         >
           <h2>{depute.Nom}</h2>
+          {isPresidentGroupe ? <h3>Président{depute.Sexe === "F" ? "e" : ""} du groupe</h3> : ""}
           <DeputyImage src={depute.URLPhotoAugora} alt={depute.Slug} sex={depute.Sexe} />
           <div className="deputy__icon-container">
             <div className="icon-wrapper">

--- a/src/styles/components/deputies-list/_deputy.scss
+++ b/src/styles/components/deputies-list/_deputy.scss
@@ -51,6 +51,22 @@
     font-size: 22px;
     padding-right: 10px;
   }
+  h3 {
+    margin: 0;
+    text-align: left;
+    display: flex;
+    position: absolute;
+    z-index: 1;
+    left: 10px;
+    bottom: 10px;
+    font-family: $font;
+    font-size: 18px;
+    flex-wrap: wrap;
+    max-width: 20%;
+  }
+  &__president {
+    grid-column-end: span 2;
+  }
   .deputy {
     &__photo {
       position: absolute;

--- a/src/styles/components/deputies-list/_deputy.scss
+++ b/src/styles/components/deputies-list/_deputy.scss
@@ -62,7 +62,7 @@
     font-family: $font;
     font-size: 18px;
     flex-wrap: wrap;
-    max-width: 20%;
+    max-width: 22%;
   }
   &__president {
     grid-column-end: span 2;


### PR DESCRIPTION
… and precise his/her role

<!--
## Liste des vérifications et actions 🚨
Merci de prendre le temps de lire les [directives pour contribuer](../CONTRIBUTING.md) pour ce projet.
- Définir le label en **notify** si cette pull request est associée à une tâche **Clickup**
- Définir les "reviewers" : **KevinBacas** et **pierretusseau**
- Définir la personne assignée à cette pull request
-->

### Description

Cette pull request a pour but de distinguer les présidents de groupe des membres. Lorsqu'on affiche un groupe uniquement, le président de groupe : 
- est affiché en premier parmi les députés du groupe
- a un bloc plus large
- a une mention de "président/e du groupe"
